### PR TITLE
Fix: Add @babel/runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "web": "npx expo start --web"
   },
   "dependencies": {
+    "@babel/runtime": "^7.20.0",
     "expo": "^52.0.46",
     "react": "18.3.1",
     "react-native": "0.76.9",


### PR DESCRIPTION
I've added @babel/runtime to dependencies in package.json to resolve a build error "Unable to resolve @babel/runtime/helpers/interopRequireDefault". This is often required for Babel's helper functions.