### PR TITLE
Fix: Resolve @react-navigation/native-stack bundling error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@react-navigation/native": "^6.0.0",
+        "@react-navigation/native-stack": "^6.0.0",
         "expo": "^52.0.46",
         "react": "18.3.1",
         "react-dom": "19.1.0",
@@ -2806,6 +2807,17 @@
         "react": "*"
       }
     },
+    "node_modules/@react-navigation/elements": {
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.31.tgz",
+      "integrity": "sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==",
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0"
+      }
+    },
     "node_modules/@react-navigation/native": {
       "version": "6.1.18",
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.18.tgz",
@@ -2819,6 +2831,22 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@react-navigation/native-stack": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.11.0.tgz",
+      "integrity": "sha512-U5EcUB9Q2NQspCFwYGGNJm0h6wBCOv7T30QjndmvlawLkNt7S7KWbpWyxS9XBHSIKF57RgWjfxuJNTgTstpXxw==",
+      "dependencies": {
+        "@react-navigation/elements": "^1.3.31",
+        "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@react-navigation/native": "^6.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": ">= 3.0.0",
+        "react-native-screens": ">= 3.0.0"
       }
     },
     "node_modules/@react-navigation/routers": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@babel/runtime": "^7.20.0",
     "expo": "^52.0.46",
     "@react-navigation/native": "^6.0.0",
+    "@react-navigation/native-stack": "^6.0.0",
     "react-native-screens": "^3.0.0",
     "react-native-safe-area-context": "^4.0.0",
     "react": "18.3.1",


### PR DESCRIPTION
This commit addresses a follow-up bundling error "Unable to resolve @react-navigation/native-stack".

The fix involves:
1. Adding `@react-navigation/native-stack` to the project dependencies in `package.json`.

This change, combined with the previous commit for `@react-navigation/native`, ensures that the necessary React Navigation packages are available to the bundler.

The changes were verified by attempting an Android build, which no longer shows the resolution errors.