### PR TITLE
Fix: Add babel.config.js for Reanimated initialization

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};


### PR DESCRIPTION
I added babel.config.js with the necessary 'react-native-reanimated/plugin' to resolve the "Native part of Reanimated doesn't seem to be initialized" error.

This ensures that Reanimated worklets are correctly transformed during the build process.